### PR TITLE
開発環境ではファビコン非表示

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,8 @@
     = csp_meta_tag
     -# ogp用
     = display_meta_tags(default_meta_tags)
-    = favicon_link_tag('favicon.ico')
+    = if Rails.env.production?
+      = favicon_link_tag('favicon.ico')
     %meta{content: "width=device-width, initial-scale=1", name: "viewport"}/
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
ローカルで他のrailsアプリを開いた際にfaviconが共有されてしまう現象を解決